### PR TITLE
Atomically check & take product

### DIFF
--- a/Abstractions/IProductGrain.cs
+++ b/Abstractions/IProductGrain.cs
@@ -2,7 +2,7 @@
 
 public interface IProductGrain : IGrainWithStringKey
 {
-    Task<ProductDetails?> TakeProductAsync(int quantity);
+    Task<(bool IsAvailable, ProductDetails? ProductDetails)> TryTakeProductAsync(int quantity);
 
     Task ReturnProductAsync(int quantity);
 

--- a/Grains/ProductGrain.cs
+++ b/Grains/ProductGrain.cs
@@ -25,8 +25,15 @@ internal class ProductGrain : Grain, IProductGrain
         await _product.WriteStateAsync();
     }
 
-    async Task<ProductDetails?> IProductGrain.TakeProductAsync(int quantity)
+    async Task<(bool IsAvailable, ProductDetails? ProductDetails)> IProductGrain.TryTakeProductAsync(int quantity)
     {
+        if (_product.State.Quantity < quantity)
+        {
+            return (false, null);
+        }
+
+        var claimedProduct = _product.State with { Quantity = quantity };
+
         _product.State = _product.State with
         {
             Quantity = _product.State.Quantity - quantity
@@ -34,6 +41,6 @@ internal class ProductGrain : Grain, IProductGrain
 
         await _product.WriteStateAsync();
 
-        return _product.State with { Quantity = quantity };
+        return (true, claimedProduct);
     }
 }


### PR DESCRIPTION
The ProductGrain is single threaded, but the current pattern of issuing two calls in the style of:
* Check if we can claim some items from the inventory
* Claim some items from the inventory

can result in a race condition.
E.g., if two users try to claim all remaining inventory at once, you may see a sequence like this:
* User 1 calls `GetProductAvailabilityAsync()` and sees that there are 10 items remaining
* User 2 calls `GetProductAvailabilityAsync()` and sees that there are 10 items remaining
* User 1 calls `TakeProductAsync(10)`
* User 2 calls `TakeProductAsync(10)`

Currently, this would result in -10 items in the inventory.
By merging the check & take operations into one call, we eliminate this race