### PR TITLE
Make ProductGrain the source of truth for products

### DIFF
--- a/Abstractions/IInventoryGrain.cs
+++ b/Abstractions/IInventoryGrain.cs
@@ -5,4 +5,5 @@ public interface IInventoryGrain : IGrainWithStringKey
     Task<HashSet<ProductDetails>> GetAllProductsAsync();
     
     Task AddOrUpdateProductAsync(ProductDetails productDetails);
+    Task RemoveProductAsync(string productId);
 }

--- a/Abstractions/IProductGrain.cs
+++ b/Abstractions/IProductGrain.cs
@@ -9,4 +9,6 @@ public interface IProductGrain : IGrainWithStringKey
     Task<int> GetProductAvailabilityAsync();
 
     Task CreateOrUpdateProductAsync(ProductDetails productDetails);
+
+    Task<ProductDetails> GetProductDetailsAsync();
 }

--- a/Silo/Services/InventoryService.cs
+++ b/Silo/Services/InventoryService.cs
@@ -22,6 +22,5 @@ public sealed class InventoryService : BaseClusterService
     }
 
     public Task CreateOrUpdateProductAsync(ProductDetails product) =>
-        _client.GetGrain<IInventoryGrain>(product.Category.ToString())
-            .AddOrUpdateProductAsync(product);
+        _client.GetGrain<IProductGrain>(product.Id).CreateOrUpdateProductAsync(product);
 }

--- a/Silo/StartupTasks/SeedProductStoreTask.cs
+++ b/Silo/StartupTasks/SeedProductStoreTask.cs
@@ -10,18 +10,11 @@
         async Task IStartupTask.Execute(CancellationToken cancellationToken)
         {            
             var faker = new ProductDetails().GetBogusFaker();
-            var inventoryGrains = Enum.GetValues<ProductCategory>()
-                .Select(category => (
-                    Category: category,
-                    Grain: _grainFactory.GetGrain<IInventoryGrain>(category.ToString())))
-                .ToDictionary(
-                    keySelector: t => t.Category,
-                    elementSelector: t => t.Grain);
 
             foreach (var product in faker.GenerateLazy(50))
             {
-                var grain = inventoryGrains[product.Category];
-                await grain.AddOrUpdateProductAsync(product);
+                var productGrain = _grainFactory.GetGrain<IProductGrain>(product.Id);
+                await productGrain.CreateOrUpdateProductAsync(product);
             }
         }
     }


### PR DESCRIPTION
InventoryGrain now persists a hash set of product ids, but has a cache of product details which it populates at activation time.
The ProductGrain keeps the InventoryGrain up to date, so all updates go through the ProductGrain.